### PR TITLE
base: SystemUI: fix custom header dpi change behaviour

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/omni/StatusBarHeaderMachine.java
+++ b/packages/SystemUI/src/com/android/systemui/omni/StatusBarHeaderMachine.java
@@ -40,6 +40,8 @@ import java.util.Calendar;
 import java.util.Map;
 import java.util.HashMap;
 
+import com.android.systemui.statusbar.phone.QuickStatusBarHeader;
+
 public class StatusBarHeaderMachine {
 
     private static final String TAG = "StatusBarHeaderMachine";
@@ -171,6 +173,24 @@ public class StatusBarHeaderMachine {
     }
 
     public void addObserver(IStatusBarHeaderMachineObserver observer) {
+        if (DEBUG) Log.i(TAG, "addObserver " + observer);
+
+        // there can only be one of that kind at a time
+        // so remove the old one first
+        if (observer instanceof QuickStatusBarHeader) {
+            IStatusBarHeaderMachineObserver prevObserver = null;
+            Iterator<IStatusBarHeaderMachineObserver> nextObserver = mObservers.iterator();
+            while (nextObserver.hasNext()) {
+                IStatusBarHeaderMachineObserver o = nextObserver.next();
+                if (o instanceof QuickStatusBarHeader) {
+                    prevObserver = o;
+                }
+            }
+            if (prevObserver != null) {
+                if (DEBUG) Log.i(TAG, "addObserver remove obsolete old " + prevObserver);
+                mObservers.remove(prevObserver);
+            }
+        }
         if (!mObservers.contains(observer)) {
             mObservers.add(observer);
         }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -1061,6 +1061,8 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
             createUserSwitcher();
         }
 
+        mStatusBarHeaderMachine = new StatusBarHeaderMachine(mContext);
+
         // Set up the quick settings tile panel
         AutoReinflateContainer container = (AutoReinflateContainer) mStatusBarWindow.findViewById(
                 R.id.qs_auto_reinflate_container);
@@ -1083,6 +1085,13 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
                     mQSPanel.setBrightnessMirror(mBrightnessMirrorController);
                     mKeyguardStatusBar.setQSPanel(mQSPanel);
                     mHeader = qsContainer.getHeader();
+
+                    // on dpi changes the header is recreated so we need
+                    // to add the new one again as addObserver
+                    // the old one will be removed in the same step
+                    mStatusBarHeaderMachine.addObserver((QuickStatusBarHeader) mHeader);
+                    mStatusBarHeaderMachine.updateEnablement();
+
                     initSignalCluster(mHeader);
                     mHeader.setActivityStarter(PhoneStatusBar.this);
                 }
@@ -1158,10 +1167,6 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
 
         // Private API call to make the shadows look better for Recents
         ThreadedRenderer.overrideProperty("ambientRatio", String.valueOf(1.5f));
-
-        mStatusBarHeaderMachine = new StatusBarHeaderMachine(mContext);
-        mStatusBarHeaderMachine.addObserver((QuickStatusBarHeader) mHeader);
-        mStatusBarHeaderMachine.updateEnablement();
 
         return mStatusBarView;
     }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/QuickStatusBarHeader.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/QuickStatusBarHeader.java
@@ -169,14 +169,6 @@ public class QuickStatusBarHeader extends BaseStatusBarHeader implements
         mBackgroundImage = (ImageView) findViewById(R.id.background_image);
 
         updateResources();
-
-        post(new Runnable() {
-            public void run() {
-                LinearLayout.LayoutParams params = (LinearLayout.LayoutParams) mBackgroundImage.getLayoutParams();
-                params.height = getExpandedHeight();
-                mBackgroundImage.setLayoutParams(params);
-            }
-        });
     }
 
     @Override
@@ -207,6 +199,14 @@ public class QuickStatusBarHeader extends BaseStatusBarHeader implements
 
         mQsPanelOffsetNormal = getResources().getDimensionPixelSize(R.dimen.qs_panel_top_offset_normal);
         mQsPanelOffsetHeader = getResources().getDimensionPixelSize(R.dimen.qs_panel_top_offset_header);
+
+        post(new Runnable() {
+            public void run() {
+                setHeaderImageHeight();
+                // the dimens could have been changed
+                setQsPanelOffset();
+            }
+        });
     }
 
     protected void updateSettingsAnimator() {
@@ -464,12 +464,7 @@ public class QuickStatusBarHeader extends BaseStatusBarHeader implements
             // to have more space for the header image
             post(new Runnable() {
                 public void run() {
-                    final boolean customHeader = Settings.System.getIntForUser(mContext.getContentResolver(),
-                            Settings.System.STATUS_BAR_CUSTOM_HEADER, 0,
-                            UserHandle.USER_CURRENT) != 0;
-                    FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) mQsPanel.getLayoutParams();
-                    params.setMargins(0, customHeader ? mQsPanelOffsetHeader : mQsPanelOffsetNormal, 0, 0);
-                    mQsPanel.setLayoutParams(params);
+                    setQsPanelOffset();
                 }
             });
         }
@@ -547,5 +542,20 @@ public class QuickStatusBarHeader extends BaseStatusBarHeader implements
                 mBackgroundImage.setForeground(null);
             }
         }
+    }
+
+    private void setQsPanelOffset() {
+        final boolean customHeader = Settings.System.getIntForUser(mContext.getContentResolver(),
+                Settings.System.STATUS_BAR_CUSTOM_HEADER, 0,
+                UserHandle.USER_CURRENT) != 0;
+        FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) mQsPanel.getLayoutParams();
+        params.setMargins(0, customHeader ? mQsPanelOffsetHeader : mQsPanelOffsetNormal, 0, 0);
+        mQsPanel.setLayoutParams(params);
+    }
+
+    private void setHeaderImageHeight() {
+        LinearLayout.LayoutParams p = (LinearLayout.LayoutParams) mBackgroundImage.getLayoutParams();
+        p.height = getExpandedHeight();
+        mBackgroundImage.setLayoutParams(p);
     }
 }


### PR DESCRIPTION
on dpi changes the complete QuickStatusBarHeader is recreated
so it must be readded as observer to StatusBarHeaderMachine

Change-Id: I2ddbd6abb4df747af640cbb6cb05b2260b5b30d3