### PR TITLE
base: correct teal for DayNight dark mode in system

### DIFF
--- a/core/res/res/values-night/custom_colors.xml
+++ b/core/res/res/values-night/custom_colors.xml
@@ -18,6 +18,8 @@
 */
 -->
 <resources>
+    <color name="accent_material_light">@color/material_deep_teal_500</color>
+    <color name="accent_material_dark">@color/material_deep_teal_500</color>
     <color name="global_actions_text_color">@color/primary_text_default_material_dark</color>
-    <color name="global_actions_icon_color">@color/material_deep_teal_200</color>
+    <color name="global_actions_icon_color">@color/accent_material_light</color>
 </resources>

--- a/core/res/res/values/colors_material.xml
+++ b/core/res/res/values/colors_material.xml
@@ -37,7 +37,7 @@
     <color name="quaternary_material_settings">@color/material_blue_grey_200</color>
 
     <color name="accent_material_light">@color/material_deep_teal_500</color>
-    <color name="accent_material_dark">@color/material_deep_teal_200</color>
+    <color name="accent_material_dark">@color/material_deep_teal_500</color>
 
     <color name="button_material_dark">#ff5a595b</color>
     <color name="button_material_light">#ffd6d7d7</color>

--- a/core/res/res/values/custom_colors.xml
+++ b/core/res/res/values/custom_colors.xml
@@ -19,5 +19,5 @@
 -->
 <resources>
     <color name="global_actions_text_color">@color/primary_text_default_material_light</color>
-    <color name="global_actions_icon_color">@color/material_deep_teal_500</color>
+    <color name="global_actions_icon_color">@color/accent_material_light</color>
 </resources>

--- a/packages/SystemUI/res/values/styles.xml
+++ b/packages/SystemUI/res/values/styles.xml
@@ -317,12 +317,12 @@
         <item name="android:layout_height">48dp</item>
     </style>
 
-    <style name="TunerSettings" parent="@android:style/Theme.Material.Settings">
+    <style name="TunerSettings" parent="@android:style/Theme.DeviceDefault.Settings">
         <item name="android:windowActionBar">false</item>
         <item name="preferenceTheme">@style/TunerPreferenceTheme</item>
     </style>
 
-    <style name="TunerPreferenceTheme" parent="@android:style/Theme.Material.Settings">
+    <style name="TunerPreferenceTheme" parent="@android:style/Theme.DeviceDefault.Settings">
         <item name="dropdownPreferenceStyle">@style/Preference.DropDown.Material</item>
     </style>
 


### PR DESCRIPTION
adjust style of Tuner activity to match Settings theme.
use teal_500 as default accent also for normal dark mode
see e.g. SystemUI

Change-Id: I33f6a5b524a2c81826bc6aa7660c888f8b9dc85c