### PR TITLE
base: notifications: DEFAULT_LIGHTS and FLAG_SHOW_LIGHTS must count a…

### DIFF
--- a/services/core/java/com/android/server/notification/NotificationRecord.java
+++ b/services/core/java/com/android/server/notification/NotificationRecord.java
@@ -144,8 +144,10 @@ public final class NotificationRecord {
 
         boolean isNoisy = (n.defaults & Notification.DEFAULT_SOUND) != 0
                 || (n.defaults & Notification.DEFAULT_VIBRATE) != 0
+                || (n.defaults & Notification.DEFAULT_LIGHTS) != 0
                 || n.sound != null
-                || n.vibrate != null;
+                || n.vibrate != null
+                || (n.flags & Notification.FLAG_SHOW_LIGHTS) != 0;
         stats.isNoisy = isNoisy;
 
         if (!isNoisy && importance > IMPORTANCE_LOW) {


### PR DESCRIPTION
…s noisy

else LED notifications will not correctly work without
force bypass dnd mode since they are not passing canInterrupt
in buzzBeepBlinkLocked in NotificationManagerService

Change-Id: I89360adc86426a6d2865a6347a09a0ab233057ea