### PR TITLE
[1/2] base: OmniSwitch: add preload task broadcast

### DIFF
--- a/core/java/com/android/internal/util/omni/OmniSwitchConstants.java
+++ b/core/java/com/android/internal/util/omni/OmniSwitchConstants.java
@@ -33,7 +33,12 @@ public class OmniSwitchConstants {
     /**
      * Intent broadcast action for toogle the omniswitch overlay
      */
-    private static final String ACTION_TOGGLE_OVERLAY = APP_PACKAGE_NAME + ".ACTION_TOGGLE_OVERLAY";
+    private static final String ACTION_TOGGLE_OVERLAY2 = APP_PACKAGE_NAME + ".ACTION_TOGGLE_OVERLAY2";
+
+    /**
+     * Intent broadcast action for telling omniswitch to preload tasks
+     */
+    private static final String ACTION_PRELOAD_TASKS = APP_PACKAGE_NAME + ".ACTION_PRELOAD_TASKS";
 
     private static final String ACTION_RESTORE_HOME_STACK = APP_PACKAGE_NAME + ".ACTION_RESTORE_HOME_STACK";
 
@@ -61,12 +66,26 @@ public class OmniSwitchConstants {
      * @hide
      */
     public static void toggleOmniSwitchRecents(Context context, UserHandle user) {
-        final Intent showIntent = new Intent(OmniSwitchConstants.ACTION_TOGGLE_OVERLAY);
-        context.sendBroadcastAsUser(showIntent, user);
+        final Intent intent = new Intent(OmniSwitchConstants.ACTION_TOGGLE_OVERLAY2);
+        intent.setPackage(APP_PACKAGE_NAME);
+        context.sendBroadcastAsUser(intent, user);
     }
 
-    public static void restoreHomeStack(Context context, UserHandle user) {
-        final Intent showIntent = new Intent(OmniSwitchConstants.ACTION_RESTORE_HOME_STACK);
-        context.sendBroadcastAsUser(showIntent, user);
+    /**
+     * @hide
+     */
+     public static void restoreHomeStack(Context context, UserHandle user) {
+        final Intent intent = new Intent(OmniSwitchConstants.ACTION_RESTORE_HOME_STACK);
+        intent.setPackage(APP_PACKAGE_NAME);
+        context.sendBroadcastAsUser(intent, user);
+    }
+
+    /**
+     * @hide
+     */
+     public static void preloadOmniSwitchRecents(Context context, UserHandle user) {
+        final Intent intent = new Intent(OmniSwitchConstants.ACTION_PRELOAD_TASKS);
+        intent.setPackage(APP_PACKAGE_NAME);
+        context.sendBroadcastAsUser(intent, user);
     }
 }

--- a/core/res/AndroidManifest.xml
+++ b/core/res/AndroidManifest.xml
@@ -496,8 +496,9 @@
 
     <protected-broadcast android:name="com.android.server.retaildemo.ACTION_RESET_DEMO" />
 
-    <protected-broadcast android:name="org.omnirom.omniswitch.ACTION_TOGGLE_OVERLAY" />
+    <protected-broadcast android:name="org.omnirom.omniswitch.ACTION_TOGGLE_OVERLAY2" />
     <protected-broadcast android:name="org.omnirom.omniswitch.ACTION_RESTORE_HOME_STACK" />
+    <protected-broadcast android:name="org.omnirom.omniswitch.ACTION_PRELOAD_TASKS" />
 
     <protected-broadcast android:name="projekt.substratum.APP_CRASHED" />
 

--- a/packages/SystemUI/src/com/android/systemui/statusbar/BaseStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/BaseStatusBar.java
@@ -92,6 +92,7 @@ import com.android.internal.messages.SystemMessageProto.SystemMessage;
 import com.android.internal.statusbar.IStatusBarService;
 import com.android.internal.statusbar.StatusBarIcon;
 import com.android.internal.widget.LockPatternUtils;
+import com.android.internal.util.omni.OmniSwitchConstants;
 import com.android.keyguard.KeyguardHostView.OnDismissAction;
 import com.android.keyguard.KeyguardUpdateMonitor;
 import com.android.systemui.DejankUtils;
@@ -277,6 +278,9 @@ public abstract class BaseStatusBar extends SystemUI implements
     protected boolean mVrMode;
 
     private Set<String> mNonBlockablePkgs;
+
+    // Omni additions
+    protected boolean mOmniSwitchRecents;
 
     @Override  // NotificationData.Environment
     public boolean isDeviceProvisioned() {
@@ -1340,12 +1344,20 @@ public abstract class BaseStatusBar extends SystemUI implements
         public boolean onTouch(View v, MotionEvent event) {
             int action = event.getAction() & MotionEvent.ACTION_MASK;
             if (action == MotionEvent.ACTION_DOWN) {
-                preloadRecents();
+                if (mOmniSwitchRecents) {
+                    OmniSwitchConstants.preloadOmniSwitchRecents(mContext, UserHandle.CURRENT);
+                } else {
+                    preloadRecents();
+                }
             } else if (action == MotionEvent.ACTION_CANCEL) {
-                cancelPreloadingRecents();
+                if (!mOmniSwitchRecents) {
+                    cancelPreloadingRecents();
+                }
             } else if (action == MotionEvent.ACTION_UP) {
                 if (!v.isPressed()) {
-                    cancelPreloadingRecents();
+                    if (!mOmniSwitchRecents) {
+                        cancelPreloadingRecents();
+                    }
                 }
 
             }

--- a/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/phone/PhoneStatusBar.java
@@ -430,7 +430,6 @@ public class PhoneStatusBar extends BaseStatusBar implements DemoMode,
     private int mInitialTouchY;
     private IPowerManager mPower;
     private boolean mDoubleTabSleep;
-    private boolean mOmniSwitchRecents;
     private boolean mHideLockscreenArtwork;
     private StatusBarHeaderMachine mStatusBarHeaderMachine;
 

--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -4140,10 +4140,11 @@ public class PhoneWindowManager implements WindowManagerPolicy {
     }
 
     private void preloadRecentApps() {
-        if (mOmniSwitchRecents) {
+        if (keyguardOn()) {
             return;
         }
-        if (keyguardOn()) {
+        if (mOmniSwitchRecents) {
+            OmniSwitchConstants.preloadOmniSwitchRecents(mContext, UserHandle.CURRENT);
             return;
         }
         mPreloadedRecentApps = true;
@@ -4154,10 +4155,10 @@ public class PhoneWindowManager implements WindowManagerPolicy {
     }
 
     private void cancelPreloadRecentApps() {
-        if (mOmniSwitchRecents) {
+        if (keyguardOn()) {
             return;
         }
-        if (keyguardOn()) {
+        if (mOmniSwitchRecents) {
             return;
         }
         if (mPreloadedRecentApps) {


### PR DESCRIPTION
Broadcast also the preload phase to OmniSwitch to get
an early start on loading tasks like stock recents

Add: relying on broadcasts for all of this gets
worse. It takes a very long time after rebooting
until broadcasts will be processed leaving
users without reaction on button presses even
if the drag handle is already there for some time

Change-Id: I976ee46d4863e7667faaa038b30ced481b934b47