### PR TITLE
base: Fix LED short blink during charge

### DIFF
--- a/services/core/java/com/android/server/BatteryService.java
+++ b/services/core/java/com/android/server/BatteryService.java
@@ -834,46 +834,56 @@ public final class BatteryService extends SystemService {
         public void updateLightsLocked() {
             final int level = mBatteryProps.batteryLevel;
             final int status = mBatteryProps.batteryStatus;
+            boolean lightEnabled = mLightEnabled;
+            int lightColor = mBatteryLowARGB;
+            boolean pulseColor = false;
+
             if (!mLightEnabled) {
                 // No lights if explicitly disabled
-                mBatteryLight.turnOff();
+                lightEnabled = false;
             } else if (level < mLowBatteryWarningLevel) {
                 if (status == BatteryManager.BATTERY_STATUS_CHARGING) {
                     // Solid red when battery is charging
-                    mBatteryLight.setColor(mBatteryLowARGB);
-                    if (mLightOnlyFullyCharged) {
-                        mBatteryLight.turnOff();
-                    }
+                    lightEnabled = !mLightOnlyFullyCharged;
+                    lightColor = mBatteryLowARGB;
                 } else if (mLedPulseEnabled) {
                     // Flash red when battery is low and not charging
-                    mBatteryLight.setFlashing(mBatteryLowARGB, Light.LIGHT_FLASH_TIMED,
-                            mBatteryLedOn, mBatteryLedOff);
+                    pulseColor = true;
+                    lightEnabled = true;
+                    lightColor = mBatteryLowARGB;
                 } else {
                     // "Pulse low battery light" is disabled, no lights.
-                    mBatteryLight.turnOff();
+                    lightEnabled = false;
                 }
             } else if (status == BatteryManager.BATTERY_STATUS_CHARGING
                     || status == BatteryManager.BATTERY_STATUS_FULL) {
                 if (status == BatteryManager.BATTERY_STATUS_FULL || level >= 90) {
                     if (level == 100){
                         // Battery is really full
-                        mBatteryLight.setColor(mBatteryReallyFullARGB);
+                        lightEnabled = true;
+                        lightColor = mBatteryReallyFullARGB;
                     } else {
                         // Battery is full or charging and nearly full
-                        mBatteryLight.setColor(mBatteryFullARGB);
-                        if (mLightOnlyFullyCharged) {
-                            mBatteryLight.turnOff();
-                        }
+                        lightEnabled = !mLightOnlyFullyCharged;
+                        lightColor = mBatteryFullARGB;
                     }
                 } else {
                     // Battery is charging and halfway full
-                    mBatteryLight.setColor(mBatteryMediumARGB);
-                    if (mLightOnlyFullyCharged) {
-                        mBatteryLight.turnOff();
-                    }
+                    lightEnabled = !mLightOnlyFullyCharged;
+                    lightColor = mBatteryMediumARGB;
                 }
             } else {
                 // No lights if not charging and not low
+                lightEnabled = false;
+            }
+            if (lightEnabled) {
+                if (pulseColor) {
+                    mBatteryLight.setFlashing(lightColor, Light.LIGHT_FLASH_TIMED,
+                            mBatteryLedOn, mBatteryLedOff);
+                } else {
+                    mBatteryLight.setColor(lightColor);
+                }
+            } else {
                 mBatteryLight.turnOff();
             }
         }


### PR DESCRIPTION
If 'Only light up when fully charged' is enabled, a short LED blink
was to be seen during charge on every ACTION_BATTERY_CHANGED intent.
Move the check up and bail out earlier now.

PS2: rework the method by moving all mLights access to the end

Change-Id: I9c2421765aa1bc22f57aeab3e4de7c6951bceecd