### PR TITLE
base: SystemUI: fix qs brightness slider visibility

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/qs/QSAnimator.java
+++ b/packages/SystemUI/src/com/android/systemui/qs/QSAnimator.java
@@ -262,6 +262,10 @@ public class QSAnimator implements Callback, PageListener, Listener, OnLayoutCha
                 .setListener(this)
                 .setEndDelay(.5f)
                 .build();
+            View brightness = mQsPanel.getBrightnessView();
+            if (brightness != null) {
+                mAllViews.add(brightness);
+            }
         }
         mNonfirstPageAnimator = new TouchAnimator.Builder()
                 .addFloat(mQuickQsPanel, "alpha", 1, 0)


### PR DESCRIPTION
on lock screen with quick scroll enabled the brightness
slider must made visible too :)

Change-Id: I6639ae85b879da362a3f5c381b3a62f39029b844