### PR TITLE
Performance Optimization: Align texture dirty rect

### DIFF
--- a/libs/hwui/font/CacheTexture.cpp
+++ b/libs/hwui/font/CacheTexture.cpp
@@ -188,15 +188,21 @@ void CacheTexture::allocatePixelBuffer() {
 bool CacheTexture::upload() {
     const Rect& dirtyRect = mDirtyRect;
 
-    uint32_t x = mHasUnpackRowLength ? dirtyRect.left : 0;
-    uint32_t y = dirtyRect.top;
-    uint32_t width = mHasUnpackRowLength ? dirtyRect.getWidth() : getWidth();
-    uint32_t height = dirtyRect.getHeight();
+    // align the x direction to 32 and y direction to 4 for better performance
+    uint32_t x = (((uint32_t)dirtyRect.left) & (~0x1F));
+    uint32_t y = (((uint32_t)dirtyRect.top) & (~0x3));
+    uint32_t r = ((((uint32_t)dirtyRect.right) + 0x1F) & (~0x1F)) - x;
+    uint32_t b = ((((uint32_t)dirtyRect.bottom) + 0x3) & (~0x3)) - y;
+    uint32_t width = (r > getWidth() ? getWidth() : r);
+    uint32_t height = (b > getHeight() ? getHeight() : b);
 
     // The unpack row length only needs to be specified when a new
     // texture is bound
     if (mHasUnpackRowLength) {
         glPixelStorei(GL_UNPACK_ROW_LENGTH, getWidth());
+    } else {
+        x = 0;
+        width = getWidth();
     }
 
     mPixelBuffer->upload(x, y, width, height);


### PR DESCRIPTION
Align x offset and width to 32, y offset and height to 4.
It improves the font texture upload performance.

CRs-Fixed: 1031411
Change-Id: Ifee5ae334a58254a63a89535bb443fe5f80e7ba0