### PR TITLE
base: fix goto sleep on long press home

### DIFF
--- a/services/core/java/com/android/server/policy/PhoneWindowManager.java
+++ b/services/core/java/com/android/server/policy/PhoneWindowManager.java
@@ -8818,6 +8818,11 @@ public class PhoneWindowManager implements WindowManagerPolicy {
                 break;
             case KEY_ACTION_SLEEP:
                 mPowerManager.goToSleep(SystemClock.uptimeMillis(), PowerManager.GO_TO_SLEEP_REASON_POWER_BUTTON, 0);
+                // in the goto sleep case we wont get a up event that will reset this to the correct state
+                if (mHomePressed) {
+                    mHomeConsumed = false;
+                    mHomePressed = false;
+                }
                 break;
             default:
                 break;


### PR DESCRIPTION
this needs special care. in case of goto sleep there
is no up event delievered that would reset all variables
to the correct state for next home press

Change-Id: I9ca072137ece59bc98f471d39716cedc4b12aaf0