### PR TITLE
[1/3] base: Disable ADB over network on disconnect

### DIFF
--- a/core/java/android/provider/Settings.java
+++ b/core/java/android/provider/Settings.java
@@ -3483,6 +3483,13 @@ public final class Settings {
         public static final String SCREENSHOT_CROP_BEHAVIOR = "screenshot_crop_behavior";
 
         /**
+         * Whether ADB over network should be disabled when the device gets disconnected from network
+         * The value is boolean (1 or 0).
+         * @hide
+         */
+        public static final String DISABLE_ADB_NETWORK_ON_DISCONNECT = "disable_adb_network_on_disconnect";
+
+        /**
          * Whether the battery light should be enabled (if hardware supports it)
          * The value is boolean (1 or 0).
          * @hide


### PR DESCRIPTION
ADB over network is not disabled before the next reboot, which creates
a potential security threat when this setting is left enabled and the
device gets re-connected to public wifi networks.

To mitigate that risk, introduce a new switch to disable ADB over network
as soon as the device gets disconnected from wifi.

Change-Id: I78d39aabde20a5c0f3460b998979b6940a09f56a